### PR TITLE
feat: add `dialog` component

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -13,7 +13,8 @@
       "recommended": true,
       "correctness": {
         "useJsxKeyInIterable": "off"
-      }
+      },
+      "a11y": { "useKeyWithClickEvents": "off" }
     }
   }
 }

--- a/packages/components/dialog/function.tsx
+++ b/packages/components/dialog/function.tsx
@@ -1,0 +1,21 @@
+import { render } from "solid-js/web";
+import type { DialogProps } from ".";
+import Dialog from ".";
+
+export const showDialog = (props: Omit<DialogProps, "show" | "onClose">) => {
+  const div = document.createElement("div");
+  document.body.appendChild(div);
+
+  const destroy = () => {
+    render(() => null, div);
+    div.remove();
+  };
+
+  const onClose = () => {
+    destroy();
+  };
+
+  render(() => <Dialog {...props} show={true} onClose={onClose} />, div);
+
+  return destroy;
+};

--- a/packages/components/dialog/index.scss
+++ b/packages/components/dialog/index.scss
@@ -1,0 +1,41 @@
+.alley-dialog {
+  position: fixed;
+  z-index: 9999;
+  width: 100vw;
+  height: 100vh;
+  left: 0;
+  top: 0;
+
+  &-mask {
+    background-color: var(--alley-color-mask);
+    width: 100vw;
+    height: 100vh;
+  }
+
+  &-wrapper {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    background-color: var(--alley-color-bg);
+    border-radius: var(--alley-border-radius);
+    padding: var(--alley-padding);
+    min-width: 160px;
+    min-height: 80px;
+  }
+
+  &-header {
+    position: relative;
+    // height: 32px;
+  }
+
+  &-close-button {
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+}
+
+body:has(.alley-dialog-hide-scrollbar) {
+  overflow: hidden;
+}

--- a/packages/components/dialog/index.tsx
+++ b/packages/components/dialog/index.tsx
@@ -1,0 +1,104 @@
+import {
+  children,
+  createEffect,
+  createSignal,
+  type JSX,
+  lazy,
+  mergeProps,
+  Show,
+} from "solid-js";
+import "./index.scss";
+import type { BaseNoChildrenComponentProps, SizeType } from "~/interface";
+import { addClassNames } from "~/utils";
+import { Portal } from "solid-js/web";
+import { AiOutlineClose } from "solid-icons/ai";
+
+const LazyButton = lazy(() => import("../button"));
+const Title = lazy(() => import("../typography/title"));
+
+const baseClass = "alley-dialog";
+
+type DialogType = "info" | "success" | "warning" | "error";
+
+export interface DialogProps
+  extends BaseNoChildrenComponentProps<HTMLDivElement> {
+  show?: boolean;
+  onClose: () => void;
+  title?: JSX.Element;
+  size?: SizeType;
+  type?: DialogType;
+  children: JSX.Element;
+  showCloseIcon?: boolean;
+  foot?: JSX.Element;
+  showMask?: boolean;
+  hideScrollbar?: boolean;
+  maskClosable?: boolean;
+}
+
+const Dialog = (props: DialogProps) => {
+  const merged = mergeProps(
+    { showMask: true, hideScrollbar: true, maskClosable: true },
+    props,
+  );
+
+  const [isVisible, setIsVisible] = createSignal(merged.show || false);
+
+  createEffect(() => {
+    setIsVisible(merged.show || false);
+  });
+
+  const handleClose = () => {
+    setIsVisible(false);
+    merged.onClose();
+  };
+
+  const classes = () =>
+    addClassNames(
+      baseClass,
+      merged.hideScrollbar && `${baseClass}-hide-scrollbar`,
+      merged.size && `${baseClass}-${merged.size}`,
+      merged.class,
+    );
+  const style = () => merged.style;
+
+  const resolved = children(() => merged.children);
+
+  return (
+    <Show when={isVisible()}>
+      <Portal>
+        <div class={classes()} style={style()}>
+          <div
+            class={`${baseClass}-mask`}
+            onClick={merged.maskClosable ? handleClose : undefined}
+          />
+
+          <div class={`${baseClass}-wrapper`}>
+            <Show when={merged.showCloseIcon}>
+              <LazyButton
+                class={`${baseClass}-close-button`}
+                onClick={handleClose}
+                icon={<AiOutlineClose />}
+                type="plain"
+                shape="circle"
+                danger
+                size="small"
+              />
+            </Show>
+
+            <div class={`${baseClass}-header`}>
+              <Show when={merged.title}>
+                <Title level={5}>{merged.title}</Title>
+              </Show>
+            </div>
+            <div class={`${baseClass}-content`}>{resolved()}</div>
+            <Show when={merged.foot}>
+              <div>{merged.foot}</div>
+            </Show>
+          </div>
+        </div>
+      </Portal>
+    </Show>
+  );
+};
+
+export default Dialog;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ const children = [
   lazy(() => import("./components/list")),
   lazy(() => import("./components/segmented.tsx")),
   lazy(() => import("./components/switchs.tsx")),
+  lazy(() => import("./components/dialogs.tsx")),
 ];
 
 const LazyMenu = lazy(() => import("~/components/menu"));
@@ -32,6 +33,7 @@ const menus = [
   "列表",
   "分段控制器",
   "开关",
+  "对话框",
 ];
 
 const App = () => {

--- a/src/components/dialogs.tsx
+++ b/src/components/dialogs.tsx
@@ -1,0 +1,45 @@
+import { createSignal } from "solid-js";
+import Dialog from "~/components/dialog";
+import { showDialog } from "~/components/dialog/function";
+import { Button, Space, Typography } from "~/index";
+
+const Dialogs = () => {
+  const [hasTitle, setHasTitle] = createSignal(false);
+  const [noTitle, setNoTitle] = createSignal(false);
+
+  const handleShowDialog = () => {
+    showDialog({
+      title: "函数式对话框",
+      type: "success",
+      size: "small",
+      children: <p>这是通过函数调用的对话框</p>,
+      showCloseIcon: true,
+    });
+  };
+
+  return (
+    <>
+      <Space gap={8}>
+        <Button onClick={() => setHasTitle(true)}>有标题</Button>
+        <Button onClick={() => setNoTitle(true)}>无标题</Button>
+        <Button onClick={() => handleShowDialog()}>函数式</Button>
+      </Space>
+
+      <Dialog showCloseIcon show={noTitle()} onClose={() => setNoTitle(false)}>
+        <Typography>默认点击遮罩时可以关闭</Typography>
+      </Dialog>
+
+      <Dialog
+        showCloseIcon
+        maskClosable={false}
+        show={hasTitle()}
+        onClose={() => setHasTitle(false)}
+        title="对话框"
+      >
+        <Typography>禁止点击遮罩时关闭以防止误触</Typography>
+      </Dialog>
+    </>
+  );
+};
+
+export default Dialogs;


### PR DESCRIPTION
Tauri does not support customization of native dialog, so it is still necessary to use HTML to display dialogs that require complex styling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an accessibility configuration option for keyboard interactions.
	- Added a new dialog component to enhance user interactions with modals.
	- Implemented a utility function for dynamically displaying dialog components.
	- Created a new component for managing multiple dialog displays with varying configurations.

- **Style**
	- Defined modular SCSS styles for the new dialog component, improving UI focus and usability.

- **Bug Fixes**
	- Addressed visibility control and close handling for dynamic dialogs, ensuring proper user interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->