### PR TITLE
fix(typography/text): props.class is not applied

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alley-components",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "repository": "https://github.com/alley-rs/alley-components",
   "keywords": [
     "solid",

--- a/packages/components/typography/text.tsx
+++ b/packages/components/typography/text.tsx
@@ -1,8 +1,8 @@
+import { Match, Switch } from "solid-js";
 import type { BaseComponentProps } from "~/interface";
 import { addClassNames } from "~/utils";
 import { baseClassName } from ".";
 import "./text.scss";
-import { Match, Switch } from "solid-js";
 
 export interface TextProps extends BaseComponentProps<HTMLSpanElement> {
   type?: "secondary" | "success" | "warning" | "danger";
@@ -19,6 +19,7 @@ export interface TextProps extends BaseComponentProps<HTMLSpanElement> {
 const Text = (props: TextProps) => {
   const classes = () =>
     addClassNames(
+      props.class,
       baseClassName,
       props.type && `${baseClassName}-${props.type}`,
       props.disabled && `${baseClassName}-disabled`,
@@ -31,7 +32,13 @@ const Text = (props: TextProps) => {
     );
 
   return (
-    <span ref={props.ref} id={props.id} class={classes()} style={props.style}>
+    <span
+      ref={props.ref}
+      id={props.id}
+      class={classes()}
+      style={props.style}
+      classList={props.classList}
+    >
       <Switch fallback={props.children}>
         <Match when={props.mark}>
           <mark>{props.children}</mark>

--- a/packages/interface.ts
+++ b/packages/interface.ts
@@ -10,6 +10,7 @@ export interface BaseComponentProps<T extends HTMLElement> {
   ref?: T | ((e: T) => void);
   id?: string;
   class?: string;
+  classList?: Record<string, boolean>;
   style?: JSX.CSSProperties;
   children?: JSX.Element;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `alley-components` package to version 0.3.3, introducing potential enhancements and bug fixes.
	- Enhanced the `Text` component to support dynamic class assignment through a new `classList` property, allowing for improved styling flexibility.
	- Added an optional `classList` property to the `BaseComponentProps` interface for better management of CSS classes in components. 

- **Bug Fixes**
	- Improved handling of class names in the `Text` component for better customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->