### PR TITLE
feat(input): 输入框的 placeholder 字体设置为 :root 默认字体

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alley-components",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "repository": "https://github.com/alley-rs/alley-components",
   "keywords": [
     "solid",

--- a/packages/components/input/index.scss
+++ b/packages/components/input/index.scss
@@ -43,6 +43,10 @@ $base: "alley-input";
     box-sizing: border-box;
   }
 
+  &::placeholder {
+    font-family: var(--alley-font-family);
+  }
+
   .#{$base}-input {
     font-size: inherit;
     margin: 0;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated version of the project to 0.3.6, indicating new features or bug fixes.
  
- **Style**
	- Enhanced styling for placeholder text in input components for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->