### PR TITLE
feat(hooks/useDark): add support for specifying dark mode strategy

### DIFF
--- a/packages/hooks/useDark.ts
+++ b/packages/hooks/useDark.ts
@@ -3,6 +3,14 @@ import type { Accessor, Setter } from "solid-js";
 
 type DarkMode = "dark" | "light" | "system";
 
+/**
+ * A custom hook that manages the dark mode state based on user preference or system setting.
+ * It returns an accessor to the current dark mode state and a setter to change it.
+ *
+ * @param {DarkMode} [mode="system"] - The initial mode to start with, either 'dark', 'light', or 'system'.
+ * @returns {[Accessor<boolean>, Setter<boolean>]} A tuple where the first element is an accessor that returns whether dark mode is active,
+ * and the second element is a setter that can be used to manually toggle dark mode.
+ */
 const useDark = (
   mode: DarkMode = "system",
 ): [Accessor<boolean>, Setter<boolean>] => {

--- a/packages/hooks/useDark.ts
+++ b/packages/hooks/useDark.ts
@@ -1,10 +1,17 @@
 import { createSignal, createEffect, onMount } from "solid-js";
 import type { Accessor, Setter } from "solid-js";
 
-const useDark = (): [Accessor<boolean>, Setter<boolean>] => {
-  const [isDark, setIsDark] = createSignal(false);
+type DarkMode = "dark" | "light" | "system";
+
+const useDark = (
+  mode: DarkMode = "system",
+): [Accessor<boolean>, Setter<boolean>] => {
+  const [isDark, setIsDark] = createSignal(mode === "dark");
 
   onMount(() => {
+    // 只有system模式才执行下面的监听
+    if (mode !== "system") return;
+
     // 设置默认主题色
     if (matchMedia("(prefers-color-scheme: dark)").matches) {
       setIsDark(true);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a customizable dark mode feature allowing users to select "dark," "light," or "system" preferences.
	- The initial dark mode state can now be set based on user preference.
- **Bug Fixes**
	- Improved handling of theme settings when the mode is set to "system."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->