### PR TITLE
fix(Alert): correct logic for closeSpeed default value

### DIFF
--- a/packages/components/alert/index.tsx
+++ b/packages/components/alert/index.tsx
@@ -96,7 +96,7 @@ const Alert = (props: AlertProps) => {
 
   const style = () => ({
     ...merged.style,
-    [`--${baseClassName}-close-speed`]: `${merged.closeSpeed}ms` ?? "500ms",
+    [`--${baseClassName}-close-speed`]: `${merged.closeSpeed ?? 500}ms`,
   });
 
   const handleClose = (


### PR DESCRIPTION
- Fix incorrect use of nullish coalescing operator which prevented the fallback value '500ms' from taking effect when closeSpeed is undefined or null.