### PR TITLE
fix(button): prevent hover effect on disabled buttons and fix padding…

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@rollup/plugin-typescript": "^11.1.6",
-    "@types/node": "^22.8.1",
-    "rollup-plugin-external-globals": "^0.12.0",
-    "sass": "^1.80.4",
-    "tslib": "^2.8.0",
-    "typescript": "^5.6.3",
-    "vite": "^5.4.10",
-    "vite-plugin-solid": "^2.10.2"
+    "@types/node": "^22.10.1",
+    "rollup-plugin-external-globals": "^0.12.1",
+    "sass": "^1.81.0",
+    "tslib": "^2.8.1",
+    "typescript": "^5.7.2",
+    "vite": "^5.4.11",
+    "vite-plugin-solid": "^2.11.0"
   },
   "files": [
     "lib"

--- a/packages/components/button/index.scss
+++ b/packages/components/button/index.scss
@@ -69,7 +69,7 @@ $base: "alley-button";
     box-shadow: var(--alley-button-primary-shadow);
     border: 1px solid transparent;
 
-    &:hover {
+    &:not(.#{$base}-disabled):hover {
       background-color: var(--alley-button-primary-hover);
     }
   }
@@ -104,8 +104,7 @@ $base: "alley-button";
     font-size: var(--alley-button-content-font-size-sm);
     line-height: var(--alley-button-content-line-height-sm);
     height: var(--alley-control-height-sm);
-    padding: var(--alley-button-padding-block-sm)
-      var(--alley-button-padding-inline-sm);
+    padding: var(--alley-button-padding-block-sm) var(--alley-button-padding-inline-sm);
     border-radius: var(--alley-border-radius-sm);
 
     &.#{$base}-icon-only {
@@ -123,8 +122,7 @@ $base: "alley-button";
     font-size: var(--alley-button-content-font-size-lg);
     line-height: var(--alley-button-content-line-height-lg);
     height: var(--alley-control-height-lg);
-    padding: var(--alley-button-padding-block-lg)
-      var(--alley-button-padding-inline-lg);
+    padding: var(--alley-button-padding-block-lg) var(--alley-button-padding-inline-lg);
     border-radius: var(--alley-border-radius-lg);
 
     &.#{$base}-icon-only {
@@ -198,8 +196,7 @@ $base: "alley-button";
   }
 
   &-space-compact-item {
-    border: var(--alley-line-width) var(--alley-line-type)
-      var(--alley-color-border);
+    border: var(--alley-line-width) var(--alley-line-type) var(--alley-color-border);
 
     &:not([disabled]) {
       &:hover {


### PR DESCRIPTION
… and border styles

- Prevent the hover effect from applying to disabled buttons.
- Fix padding styles for button sizes by ensuring they are defined in a single line.
- Ensure border style is defined in a single line for compact space items.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved hover interactions for button components, ensuring hover effects are disabled when buttons are inactive.
  
- **Style**
	- Enhanced readability of padding properties and border declarations in button component styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->