### PR TITLE
feat(input-number): Add support for addons and enhance styling with CSS variables

### DIFF
--- a/packages/components/input-number/index.scss
+++ b/packages/components/input-number/index.scss
@@ -1,6 +1,6 @@
 $base: "alley-input-number";
 
-.#{$base} {
+.#{$base}-css-var {
   --alley-input-number-padding-block: 4px;
   --alley-input-number-padding-block-sm: 0px;
   --alley-input-number-padding-block-lg: 7px;
@@ -28,7 +28,9 @@ $base: "alley-input-number";
   --alley-input-number-handle-hover-color: var(--alley-color-hover);
   --alley-input-number-handle-border-color: #d9d9d9;
   --alley-input-number-handle-opacity: 0;
+}
 
+.#{$base} {
   background-color: var(--alley-color-bg-container);
   border-width: var(--alley-line-width);
   border-style: var(--alley-line-type);
@@ -259,6 +261,70 @@ $base: "alley-input-number";
         border-end-end-radius: 0;
       }
     }
+  }
+
+  &-group {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    color: var(--alley-color-text);
+    font-size: var(--alley-font-size);
+    line-height: var(--alley-line-height);
+    list-style: none;
+    font-family: var(--alley-font-family);
+    position: relative;
+    display: table;
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+
+    &-addon {
+      vertical-align: middle;
+      position: relative;
+      padding: 0 var(--alley-input-number-padding-inline);
+      color: var(--alley-color-text);
+      font-weight: normal;
+      font-size: var(--alley-input-number-input-font-size);
+      text-align: center;
+      border-radius: var(--alley-border-radius);
+      transition: all var(--alley-motion-duration-slow);
+      line-height: 1;
+      background: var(--alley-input-number-addon-bg);
+      border: var(--alley-line-width) var(--alley-line-type)
+        var(--alley-color-border);
+      display: table-cell;
+      width: 1px;
+      white-space: nowrap;
+
+      &:last-child {
+        border-inline-start: 0;
+        border-start-start-radius: 0;
+        border-end-start-radius: 0;
+      }
+    }
+
+    > .#{$base}:first-child,
+    &-addon:first-child {
+      border-start-end-radius: 0;
+      border-end-end-radius: 0;
+    }
+
+    > .#{$base}:not(:first-child):not(:last-child) {
+      border-radius: 0;
+    }
+
+    .#{$base} {
+      width: 100%;
+      margin-bottom: 0;
+      text-align: inherit;
+      display: table-cell;
+    }
+  }
+
+  &-group-wrapper {
+    display: inline-block;
+    text-align: start;
+    vertical-align: top;
   }
 }
 

--- a/packages/components/input-number/index.tsx
+++ b/packages/components/input-number/index.tsx
@@ -2,7 +2,7 @@ import { VsChevronDown, VsChevronUp } from "solid-icons/vs";
 import { addClassNames } from "~/utils";
 import "./index.scss";
 import type { BaseSizeComponentProps } from "~/interface";
-import { useContext } from "solid-js";
+import { children, type JSX, Show, useContext } from "solid-js";
 import { SpaceCompactContext } from "../space/context";
 
 export interface InputNumberProps
@@ -13,6 +13,10 @@ export interface InputNumberProps
   onChange?: (value: number) => void;
   placeholder?: string;
   disabled?: boolean;
+  addonBefore?: JSX.Element;
+  addonAfter?: JSX.Element;
+  prefix?: JSX.Element;
+  suffix?: JSX.Element;
 }
 
 const baseClassName = "alley-input-number";
@@ -26,6 +30,7 @@ const InputNumber = (props: InputNumberProps) => {
   const className = () => {
     return addClassNames(
       baseClassName,
+      `${baseClassName}-css-var`,
       size() && `${baseClassName}-${size()}`,
       props.disabled && `${baseClassName}-disabled`,
       spaceCompactItemClass,
@@ -34,7 +39,7 @@ const InputNumber = (props: InputNumberProps) => {
     );
   };
 
-  return (
+  const single = children(() => (
     <div class={className()}>
       <div class={`${baseClassName}-handler-wrap`}>
         <span
@@ -54,7 +59,7 @@ const InputNumber = (props: InputNumberProps) => {
         <span
           class={`${baseClassName}-handler ${baseClassName}-handler-down`}
           onClick={() => {
-            const val = props.value ? props.value - 1 : 0;
+            const val = props.value !== undefined ? props.value - 1 : 0;
 
             if (props.min !== undefined)
               props.onChange?.(val < props.min ? props.min : val);
@@ -87,6 +92,26 @@ const InputNumber = (props: InputNumberProps) => {
         />
       </div>
     </div>
+  ));
+
+  return (
+    <Show when={props.addonBefore || props.addonAfter} fallback={single()}>
+      <div
+        class={`${baseClassName}-group-wrapper ${baseClassName}-group-wrapper-outlined ${baseClassName}-css-var`}
+      >
+        <div class={`${baseClassName}-wrapper ${baseClassName}-group`}>
+          <Show when={props.addonBefore}>
+            <div class={`${baseClassName}ant-input-number-group-addon`}>
+              {props.addonBefore}
+            </div>
+          </Show>
+          {single()}
+          <Show when={props.addonAfter}>
+            <div class={`${baseClassName}-group-addon`}>{props.addonAfter}</div>
+          </Show>
+        </div>
+      </div>
+    </Show>
   );
 };
 

--- a/src/components/inputs.tsx
+++ b/src/components/inputs.tsx
@@ -62,6 +62,16 @@ const Inputs = () => {
         </Space>
 
         <Space align="center">
+          <Label>后缀</Label>
+          <InputNumber
+            value={count()}
+            onChange={setCount}
+            min={-100}
+            addonAfter="$"
+          />
+        </Space>
+
+        <Space align="center">
           <Label>紧凑模式（大）</Label>
           <Space.Compact size="large">
             <InputNumber value={count()} onChange={setCount} />


### PR DESCRIPTION
- Introduce CSS variables for customizable padding and colors in the input-number component.
- Add new props `addonBefore`, `addonAfter`, `prefix`, and `suffix` to InputNumber component for extended functionality.
- Implement group wrapper and addon styles for a more flexible layout.
- Adjust handler logic to account for undefined initial values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `InputNumber` component with support for `addonBefore`, `addonAfter`, `prefix`, and `suffix` properties for additional UI elements.
	- Introduced a new input field with a dollar sign suffix for monetary inputs.
  
- **Style**
	- Restructured CSS classes and added new CSS variables for better customization of the `InputNumber` component.
	- Added new styles for grouping input elements and additional elements within the `InputNumber`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->